### PR TITLE
Fix incorrect git clone URL in installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ This script is intended to be used as an example of blind atomic MEV and how to 
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/yourusername/simple-blind-arbitrage.git
+git clone https://github.com/flashbots/simple-blind-arbitrage.git
 ```
 
 2. Change to the project directory:


### PR DESCRIPTION
## Overview

During my recent work with the installation guide in the repository, I encountered a small but potentially confusing detail. The Git clone command in the instructions uses a placeholder for the username. This could be misleading, especially for newcomers to GitHub who are attempting to clone the repository.

This PR aims to address and rectify this minor issue to enhance user comprehension and ease of setup.